### PR TITLE
Enable browser logs

### DIFF
--- a/src/services/raceService.js
+++ b/src/services/raceService.js
@@ -20,7 +20,8 @@ class RaceService {
                 defaultViewport: {
                     width: 1280,
                     height: 800
-                }
+                },
+                dumpio: true,
             };
 
             // Add environment info logging


### PR DESCRIPTION
This PR enables browser logs by setting `"dumpio": true`. 